### PR TITLE
Improve bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,11 +13,11 @@
   ],
   "dependencies": {
     "bootstrap": "~3.2.0",
-    "angular": "1.2.5",
+    "angular": "~1.2.5",
     "angular-route": "~1.2.20",
-    "ng-file-upload": "^11.2.3",
-    "recordrtc": "^5.2.7",
-    "angular-socket-io": "^0.7.0",
-    "socket.io-client": "^1.4.5"
+    "ng-file-upload": "11.2.3",
+    "recordrtc": "5.2.7",
+    "angular-socket-io": "0.7.0",
+    "socket.io-client": "1.4.5"
   }
 }


### PR DESCRIPTION
Correct some issues with previous bower.json dependencies:
- angular exact version was somehow missing, changed to allow subsequent
  patch-level changes
- removed some dependencies auto-upgrading to subsequent minor-level
  changes
