### PR TITLE
Correct get_data script path

### DIFF
--- a/backend/lib/get_data.sh
+++ b/backend/lib/get_data.sh
@@ -6,7 +6,7 @@ mkdir -p nnet_a_gpu_online graph
 tar zxvf nnet_a_gpu_online.tar.gz -C nnet_a_gpu_online
 tar zxvf graph.tar.gz -C graph
 
-for x in $1/egs/online-nnet2/nnet_a_gpu_online/conf/*conf; do
+for x in ./nnet_a_gpu_online/conf/*conf; do
   cp $x $x.orig
   sed s:/export/a09/dpovey/kaldi-clean/egs/fisher_english/s5/exp/nnet2_online/:$(pwd)/: < $x.orig > $x
 done


### PR DESCRIPTION
the `get_data` script contained an error: it changes its working
directory, then tried to run an operation from the old directory. This
did not work.
Change the instruction to take in account the fact that we are not in
the same folder anymore.
