### PR TITLE
Add missing `errorhandler` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "body-parser": "^1.0.2",
     "connect-busboy": "0.0.2",
     "diff": "^2.2.1",
+    "errorhandler":"1.4.3",
     "events": "^1.1.0",
     "express": "~4.1.1",
     "fluent-ffmpeg": "^2.0.1",


### PR DESCRIPTION
The `errorhandler` dep was somehow missing from package.json, depsite
being required by app.js. Adding it.
